### PR TITLE
Translation fix

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -413,7 +413,7 @@
     <string name="enable_gif_animation">Enable GIF animation (It wastes the battery very much)</string>
     <string name="acct_sample">(sample)username@instance</string>
     <string name="mention_full_acct">Show mention as full acct (column reload required)</string>
-    <string name="remote_profile_warning">Remote user\'s profile may be inadequate information. You can check more accurate information on the web page.</string>
+    <string name="remote_profile_warning">Information on remote profile pages may not be displayed accurately. Press here to view the profile in your browser.</string>
     <string name="public_profile">Public profile</string>
     <string name="change_avatar">Change avatar icon</string>
     <string name="change_header">Change header image</string>


### PR DESCRIPTION
Changed text for "remote_profile_warning" from 'Remote user's profile may be inadequate information. You can check more accurate information on the web page.' to 'Information on remote profile pages may not be displayed accurately. Press here to view the profile in your browser.'