### PR TITLE
Change label for "private" to "followers-only"

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -313,7 +313,7 @@
 	<string name="vibration">Vibration</string>
 	<string name="visibility">Visibilité</string>
 	<string name="visibility_direct">Direct</string>
-	<string name="visibility_private">Privé</string>
+	<string name="visibility_private">Abonnés</string>
 	<string name="visibility_public">Public</string>
 	<string name="visibility_unlisted">Non listé</string>
 	<string name="visibility_web_setting">Trace web app setting</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@
     <string name="file_size_too_big">The file is too big. Maximum limit is %1$dMB.</string>
     <string name="visibility_public">Public</string>
     <string name="visibility_unlisted">Unlisted</string>
-    <string name="visibility_private">Private</string>
+    <string name="visibility_private">Followers-only</string>
     <string name="visibility_direct">Direct</string>
     <string name="visibility_web_setting">Trace web app setting</string>
     <string name="choose_visibility">Choose visibility</string>


### PR DESCRIPTION
Matches the change done on the Mastodon web app ([`5015149`](https://github.com/tootsuite/mastodon/commit/501514960a9de238e23cd607d2e8f4c1ff9f16c1)).

I only speak English and French, I don't know if other localization files need to be updated.