### PR TITLE
Fix mentions on delete and redraft.

### DIFF
--- a/app/src/main/java/jp/juggler/subwaytooter/ActPost.kt
+++ b/app/src/main/java/jp/juggler/subwaytooter/ActPost.kt
@@ -24,6 +24,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import android.text.Editable
 import android.text.Spannable
+import android.text.SpannableStringBuilder
 import android.text.TextWatcher
 import android.text.method.LinkMovementMethod
 import android.view.View
@@ -769,7 +770,8 @@ class ActPost : AppCompatActivity(),
 						
 						var text : Spannable
 						
-						text = decodeOptions.decodeHTML(base_status.content)
+						text = fixMentions(base_status.mentions, decodeOptions.decodeHTML(base_status.content))
+
 						etContent.text = text
 						etContent.setSelection(text.length)
 						
@@ -895,7 +897,16 @@ class ActPost : AppCompatActivity(),
 		showQuotedRenote()
 		showSchedule()
 	}
-	
+
+	private fun fixMentions(mentions : Iterable<TootMention>?, text : SpannableStringBuilder) : SpannableStringBuilder {
+		var toReturn = text.toString()
+		mentions?.forEach {
+			mention ->
+			toReturn  = toReturn.replace(Regex.fromLiteral(mention.username), Regex.escapeReplacement(mention.acct))
+		}
+		return SpannableStringBuilder(toReturn)
+	}
+
 	override fun onDestroy() {
 		post_helper.onDestroy()
 		attachment_worker?.cancel()


### PR DESCRIPTION
Currently, selecting "delete and redraft" on a post mentioning someone on another instance removes the URL part of the instance. I have added code to fix this.

Before:
![Screenshot_20190702-225122](https://user-images.githubusercontent.com/10965841/60566665-6b847a00-9d1c-11e9-8d63-211f857887f8.png)

After:
![Screenshot_1562133108](https://user-images.githubusercontent.com/10965841/60566696-89ea7580-9d1c-11e9-98fd-4975287de559.png)

