### PR TITLE
Open remote url if media type is unknown

### DIFF
--- a/app/src/main/java/jp/juggler/subwaytooter/ItemViewHolder.kt
+++ b/app/src/main/java/jp/juggler/subwaytooter/ItemViewHolder.kt
@@ -2169,7 +2169,7 @@ internal class ItemViewHolder(
 					
 					// unknownが1枚だけなら内蔵ビューアを使わずにインテントを投げる
 					item.type == TootAttachmentType.Unknown && media_attachments.size == 1 ->
-						App1.openCustomTab(activity, item)
+						App1.openCustomTab(activity, item.remote_url!!)
 					
 					// 内蔵メディアビューアを使う
 					Pref.bpUseInternalMediaViewer(App1.pref) ->


### PR DESCRIPTION
Related: #116 
If media type is "unknown", local media is returning "missing.png" or 404. With this PR, It opens remote url like mastodon web's behavior.