### PR TITLE
Add redirect_uri to all token requests

### DIFF
--- a/app/src/main/java/jp/juggler/subwaytooter/api/TootApiClient.kt
+++ b/app/src/main/java/jp/juggler/subwaytooter/api/TootApiClient.kt
@@ -793,7 +793,7 @@ class TootApiClient(
                 val clientSecret = clientInfo.string("client_secret")
                     ?: return result.setError("missing client_secret")
 
-                "grant_type=client_credentials&scope=read+write&client_id=${clientId.encodePercent()}&client_secret=${clientSecret.encodePercent()}"
+                "grant_type=client_credentials&scope=read+write&client_id=${clientId.encodePercent()}&client_secret=${clientSecret.encodePercent()}&redirect_uri=${REDIRECT_URL.encodePercent()}"
                     .toFormRequestBody().toPost()
                     .url("https://${apiHost?.ascii}/oauth/token")
                     .build()


### PR DESCRIPTION
[redirect_uri is required for oauth/token](https://docs.joinmastodon.org/methods/apps/oauth/#:~:text=during%20app%20registration-,redirect_uri,REQUIRED,-string)

mastodon's oauth library is more lenient and will use the pre-registered redirect_uri, but other servers that implement mastodon's API will throw an error.