### PR TITLE
カスタム絵文字の反応のための正しいPleroma API機能フィールドを確認してくださ

### DIFF
--- a/app/src/main/java/jp/juggler/subwaytooter/api/entity/TootInstance.kt
+++ b/app/src/main/java/jp/juggler/subwaytooter/api/entity/TootInstance.kt
@@ -89,6 +89,7 @@ object InstanceCapability {
             ai.isMisskey -> true
             ti?.fedibirdCapabilities?.contains("emoji_reaction") == true -> true
             ti?.pleromaFeatures?.contains("custom_emoji_reactions") == true -> true
+            ti?.pleromaFeatures?.contains("pleroma_custom_emoji_reactions") == true -> true
             else -> false
         }
 


### PR DESCRIPTION
上流のPleromaは、APIの`pleroma_custom_emoji_reactions`フィールドを使用して、そのような機能が利用可能であることを示します [1][2]。 一部のフォークでは、互換性のあるAPIを使用しながら、非推奨の`custom_emoji_reactions`フィールドを使用しています。

[1] https://git.pleroma.social/pleroma/pleroma/-/merge_requests/3845
[2] https://eientei.org/api/v1/instance - APIレスポンスの例